### PR TITLE
sharding prototype

### DIFF
--- a/sharding_test.py
+++ b/sharding_test.py
@@ -1,0 +1,86 @@
+import json
+import os
+import shutil
+
+import zarrita
+
+
+shutil.rmtree("sharding_test.zr3", ignore_errors=True)
+h = zarrita.create_hierarchy("sharding_test.zr3")
+a = h.create_array(
+    path="testarray",
+    shape=(20, 3),
+    dtype="float64",
+    chunk_shape=(3, 2),
+    shards=(2, 2),
+)
+
+a[:10, :] = 42
+a[15, 1] = 389
+a[19, 2] = 1
+a[0, 1] = -4.2
+
+assert a.store._shards == (2, 2)
+assert a[15, 1] == 389
+assert a[19, 2] == 1
+assert a[0, 1] == -4.2
+assert a[0, 0] == 42
+
+array_json = a.store["meta/root/testarray.array.json"].decode()
+
+print(array_json)
+# {
+#     "shape": [
+#         20,
+#         3
+#     ],
+#     "data_type": "<f8",
+#     "chunk_grid": {
+#         "type": "regular",
+#         "chunk_shape": [
+#             3,
+#             2
+#         ],
+#         "separator": "/"
+#     },
+#     "chunk_memory_layout": "C",
+#     "fill_value": null,
+#     "extensions": [],
+#     "attributes": {},
+#     "shards": [
+#         2,
+#         2
+#     ],
+#     "shard_format": "indexed"
+# }
+
+assert json.loads(array_json)["shards"] == [2, 2]
+
+print("ONDISK")
+for root, dirs, files in os.walk("sharding_test.zr3"):
+    dirs.sort()
+    if len(files) > 0:
+        print("   ", root.ljust(40), *sorted(files))
+print("UNDERLYING STORE", sorted(i.rsplit("c")[-1] for i in a.store._store if i.startswith("data")))
+print("STORE", sorted(i.rsplit("c")[-1] for i in a.store if i.startswith("data")))
+# ONDISK
+#     sharding_test.zr3                        zarr.json
+#     sharding_test.zr3/data/root/testarray/c0 0
+#     sharding_test.zr3/data/root/testarray/c1 0
+#     sharding_test.zr3/data/root/testarray/c2 0
+#     sharding_test.zr3/data/root/testarray/c3 0
+#     sharding_test.zr3/meta/root              testarray.array.json
+# UNDERLYING STORE ['0/0', '1/0', '2/0', '3/0']
+# STORE ['0/0', '0/1', '1/0', '1/1', '2/0', '2/1', '3/0', '3/1', '5/0', '6/1']
+
+index_bytes = a.store._store["data/root/testarray/c0/0"][-2*2*16:]
+print("INDEX 0.0", [int.from_bytes(index_bytes[i:i+8], byteorder="little") for i in range(0, len(index_bytes), 8)])
+# INDEX 0.0 [0, 48, 48, 48, 96, 48, 144, 48]
+
+
+a_reopened = zarrita.get_hierarchy("sharding_test.zr3").get_array("testarray")
+assert a_reopened.store._shards == (2, 2)
+assert a_reopened[15, 1] == 389
+assert a_reopened[19, 2] == 1
+assert a_reopened[0, 1] == -4.2
+assert a_reopened[0, 0] == 42

--- a/sharding_test.py
+++ b/sharding_test.py
@@ -12,7 +12,7 @@ a = h.create_array(
     shape=(20, 3),
     dtype="float64",
     chunk_shape=(3, 2),
-    shards=(2, 2),
+    sharding={"chunks_per_shard": (2, 2)},
 )
 
 a[:10, :] = 42
@@ -20,7 +20,7 @@ a[15, 1] = 389
 a[19, 2] = 1
 a[0, 1] = -4.2
 
-assert a.store._shards == (2, 2)
+assert a.store._chunks_per_shard == (2, 2)
 assert a[15, 1] == 389
 assert a[19, 2] == 1
 assert a[0, 1] == -4.2
@@ -47,14 +47,16 @@ print(array_json)
 #     "fill_value": null,
 #     "extensions": [],
 #     "attributes": {},
-#     "shards": [
-#         2,
-#         2
-#     ],
-#     "shard_format": "indexed"
+#     "sharding": {
+#         "chunks_per_shard": [
+#             2,
+#             2
+#         ],
+#         "format": "indexed"
+#     }
 # }
 
-assert json.loads(array_json)["shards"] == [2, 2]
+assert json.loads(array_json)["sharding"]["chunks_per_shard"] == [2, 2]
 
 print("ONDISK")
 for root, dirs, files in os.walk("sharding_test.zr3"):
@@ -79,7 +81,7 @@ print("INDEX 0.0", [int.from_bytes(index_bytes[i:i+8], byteorder="little") for i
 
 
 a_reopened = zarrita.get_hierarchy("sharding_test.zr3").get_array("testarray")
-assert a_reopened.store._shards == (2, 2)
+assert a_reopened.store._chunks_per_shard == (2, 2)
 assert a_reopened[15, 1] == 389
 assert a_reopened[19, 2] == 1
 assert a_reopened[0, 1] == -4.2

--- a/zarrita.py
+++ b/zarrita.py
@@ -1084,10 +1084,6 @@ class Store(MutableMapping):
     def __delitem__(self, key: str) -> None:
         raise NotImplementedError
 
-    def delitems(self, keys: Iterable[str]) -> None:
-        for key in keys:
-            del self[key]
-
     def __iter__(self) -> Iterator[str]:
         raise NotImplementedError
 
@@ -1329,9 +1325,6 @@ class IndexedShardedStore(Store):
             self._store[shard_key] = shard_content
         else:
             self._store[key] = value
-
-    def delitems(self, keys: Iterable[str]) -> None:
-        raise NotImplementedError
 
     def __shard_key_to_original_keys__(self, key: str) -> Iterator[str]:
         if not _is_data_key(key):


### PR DESCRIPTION
This PR is for an early prototype of sharding support in zarrita, as described in the original issue https://github.com/zarr-developers/zarr-python/issues/877. It serves mainly to discuss the overall implementation approach for sharding. This PR is not meant to be merged.

This prototype
* allows to specify shards as the number of chunks that should be contained in a shard (e.g. using `arr.zeros((20, 3), chunks=(3, 3), shards=(2, 2), …)`).
   One shard corresponds to one storage key, but can contain multiple chunks:
  ![sharding](https://user-images.githubusercontent.com/7216331/142209119-c1c179e1-e132-463c-a64f-80cb70d62f22.png)
* ensures that this setting is persisted in the `array.json` config and loaded when opening an array again, adding two entries:
    * `"shard_format": "indexed"` specifies the binary format of the shards and allows to extend sharding with other formats later
    * `"shards": [2, 2]` specifies how many chunks are contained in a shard,
* adds a `IndexedShardedStore` class that is used to wrap the chunk-store when sharding is enabled. This store handles the grouping of multiple chunks to one shard and transparently reads and writes them via the inner store in a binary format which is specified below. The original store API does not need to be adapted, it just stores shards instead of chunks, which are translated back to chunks by the `IndexedShardedStore`.
* adds a small script `sharding_test.py` for demonstration purposes, this is not meant to be merged but servers to illustrate the changes.

-----------------

The currently implemented file format is still up for discussion. It implements "Format 2" @jbms describes in https://github.com/zarr-developers/zarr-python/pull/876#issuecomment-973462279.

Chunks are written successively in a shard (unused space between them is allowed), followed by an index referencing them.
The index holding an `offset, length` pair of little-endian uint64 per chunk, the chunks-order in the index is row-major (C) order,
e.g. for (2, 2) chunks per shard an index would look like:

```
| chunk (0, 0)    | chunk (0, 1)    | chunk (1, 0)    | chunk (1, 1)    |
| offset | length | offset | length | offset | length | offset | length |
| uint64 | uint64 | uint64 | uint64 | uint64 | uint64 | uint64 | uint64 |
```

Empty chunks are denoted by setting both offset and length to `2^64 - 1`. All the index always has the full shape of all possible chunks per shard, even if they are outside of the array size.

For the default order of the actual chunk-content in a shard I'd propose to use Morton order, but this can easily be changed and customized, since any order can be read.

-----------------

The following parts are not included in this prototype:
* [ ] Use a default write-order (Morton) of chunks in a shard and allow customization
* [ ] Support deletion in the `ShardedStore`
* [ ] Consider locking mechanisms to guard against concurrency issues within a shard
* [ ] Allow partial reads and writes when the wrapped store supports them
* [ ] Add warnings for inefficient reads/writes (might be configured)