### PR TITLE
Fix endian codec

### DIFF
--- a/zarrita/array.py
+++ b/zarrita/array.py
@@ -271,7 +271,7 @@ class Array:
             return None
 
         # ensure correct dtype
-        if str(chunk.dtype) != self.metadata.data_type.name:
+        if chunk.dtype.name != self.metadata.data_type.name:
             chunk = chunk.view(self.metadata.dtype)
 
         # ensure correct chunk shape

--- a/zarrita/codecs.py
+++ b/zarrita/codecs.py
@@ -110,7 +110,7 @@ class EndianCodecMetadata:
     ) -> ValueHandle:
         byteorder = self._get_byteorder(chunk)
         if self.configuration.endian != byteorder:
-            chunk = chunk.view(dtype=chunk.dtype.newbyteorder(byteorder))
+            chunk = chunk.view(dtype=_array_metadata.dtype.newbyteorder(self.configuration.endian))
         return ArrayHandle(chunk)
 
     @_needs_array
@@ -122,7 +122,7 @@ class EndianCodecMetadata:
     ) -> ValueHandle:
         byteorder = self._get_byteorder(chunk)
         if self.configuration.endian != byteorder:
-            chunk = chunk.view(dtype=chunk.dtype.newbyteorder(byteorder))
+            chunk = chunk.view(dtype=_array_metadata.dtype.newbyteorder(self.configuration.endian))
         return ArrayHandle(chunk)
 
 


### PR DESCRIPTION
The endian codec does not do byte swapping as it uses the host endianness and not the configuration one. There was also an issue with the data type being always float64 (likely from np.frombuffer() in BufferHandle.toarray()) instead of the array one.

On the attached test_big.zarr [test_big.zarr.zip](https://github.com/scalableminds/zarrita/files/11413031/test_big.zarr.zip), we currently get
```
$ python -c "import zarrita; store = zarrita.FileSystemStore('file://test_big.zarr'); x = zarrita.Array.open(store, '/'); print(x[:])"
[[27392 31488 33792 29440 33792 33792 35840 33792 33792 33792 27392 33792
  27392 33792 33792 27392 31488 29440 39936 37888]
 [29440 33792 27392 31488 37888 29440 42240 29440 35840 27392 31488 31488
  25344 33792 31488 33792 33792 33792 25344 39936]
 [29440 33792 35840 33792 31488 29440 35840 27392 35840 29440 33792 31488
  27392 33792 33792 29440 29440 27392 29440 27392]
 [37888 33792 31488 31488 29440 33792 33792 31488 29440 31488 29440 31488
  27392 29440 37888 27392 29440 35840 29440 33792]
 [33792 39936 33792 35840 33792 33792 29440 29440 29440 31488 37888 31488
  42240 31488 33792 27392 27392 33792 39936 31488]
 [48384 44288 44288 37888 37888 29440 37888 31488 27392 33792 29440 33792
  39936 25344 31488 29440 33792 33792 52736 27392]
 [50432 44288 37888 35840 35840 33792 25344 33792 31488 29440 35840 33792
  33792 25344 33792 31488 33792 44288 31488 29440]
 [37888 31488 37888 29440 37888 31488 35840 31488 27392 29440 33792 29440
  27392 29440 25344 31488 25344 46336 25344 27392]
 [31488 29440 33792 29440 31488 33792 29440 33792 33792 31488 31488 33792
  25344 29440 25344 31488 33792 29440 29440 27392]
 [35840 35840 25344 35840 25344 29440 31488 27392 33792 27392 29440 27392
  29440 31488 33792 31488 27392 31488 33792 33792]
 [33792 33792 33792 31488 25344 33792 31488 27392 37888 25344 29440 31488
  35840 44288 31488 27392 31488 31488 31488 27392]
 [31488 31488 31488 27392 35840 31488 31488 29440 29440 23040 27392 44288
  27392 27392 27392 27392 25344 33792 31488 29440]
 [44288 37888 25344 31488 31488 27392 31488 25344 27392 48384 44288 27392
  29440 29440 27392 25344 35840 27392 44288 35840]
 [37888 33792 33792 27392 31488 25344 25344 29440 25344 33792 25344 35840
  29440 37888 31488 25344 33792 31488 37888 35840]
 [35840 27392 35840 23040 27392 29440 27392 23040 25344 31488 29440 29440
  29440 31488 31488 37888 29440 37888 25344 33792]
 [42240 37888 39936 31488 27392 27392 27392 29440 35840 25344 29440 25344
  25344 27392 29440 33792 29440 23040 31488 29440]
 [48384 44288 35840 35840 42240 29440 33792 23040 25344 29440 23040 25344
  25344 27392 25344 33792 25344 27392 33792 33792]
 [39936 46336 35840 44288 31488 33792 25344 29440 31488 18944 29440 25344
  31488 35840 39936 33792 42240 35840 35840 25344]
 [44288 63232 65280 52736 33792 27392 35840 31488 37888 33792 42240 42240
  37888 35840 33792 31488 27392 31488 27392 31488]
 [46336 46336 39936 37888 39936 39936 39936 46336 33792 37888 29440 33792
  27392 27392 27392 27392 27392 29440 25344 27392]]
```
instead of
```
$ python -c "import zarrita; store = zarrita.FileSystemStore('file://test_big.zarr'); x = zarrita.Array.open(store, '/'); print(x[:])"
[[107 123 132 115 132 132 140 132 132 132 107 132 107 132 132 107 123 115
  156 148]
 [115 132 107 123 148 115 165 115 140 107 123 123  99 132 123 132 132 132
   99 156]
 [115 132 140 132 123 115 140 107 140 115 132 123 107 132 132 115 115 107
  115 107]
 [148 132 123 123 115 132 132 123 115 123 115 123 107 115 148 107 115 140
  115 132]
 [132 156 132 140 132 132 115 115 115 123 148 123 165 123 132 107 107 132
  156 123]
 [189 173 173 148 148 115 148 123 107 132 115 132 156  99 123 115 132 132
  206 107]
 [197 173 148 140 140 132  99 132 123 115 140 132 132  99 132 123 132 173
  123 115]
 [148 123 148 115 148 123 140 123 107 115 132 115 107 115  99 123  99 181
   99 107]
 [123 115 132 115 123 132 115 132 132 123 123 132  99 115  99 123 132 115
  115 107]
 [140 140  99 140  99 115 123 107 132 107 115 107 115 123 132 123 107 123
  132 132]
 [132 132 132 123  99 132 123 107 148  99 115 123 140 173 123 107 123 123
  123 107]
 [123 123 123 107 140 123 123 115 115  90 107 173 107 107 107 107  99 132
  123 115]
 [173 148  99 123 123 107 123  99 107 189 173 107 115 115 107  99 140 107
  173 140]
 [148 132 132 107 123  99  99 115  99 132  99 140 115 148 123  99 132 123
  148 140]
 [140 107 140  90 107 115 107  90  99 123 115 115 115 123 123 148 115 148
   99 132]
 [165 148 156 123 107 107 107 115 140  99 115  99  99 107 115 132 115  90
  123 115]
 [189 173 140 140 165 115 132  90  99 115  90  99  99 107  99 132  99 107
  132 132]
 [156 181 140 173 123 132  99 115 123  74 115  99 123 140 156 132 165 140
  140  99]
 [173 247 255 206 132 107 140 123 148 132 165 165 148 140 132 123 107 123
  107 123]
 [181 181 156 148 156 156 156 181 132 148 115 132 107 107 107 107 107 115
   99 107]]
```

Note: I only tested the decode path