### PR TITLE
Add MemoryStore

### DIFF
--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -9,7 +9,15 @@ import wkw
 import zarr
 from pytest import fixture
 
-from zarrita import Array, Group, LocalStore, MemoryStore, Store, codecs, runtime_configuration
+from zarrita import (
+    Array,
+    Group,
+    LocalStore,
+    MemoryStore,
+    Store,
+    codecs,
+    runtime_configuration,
+)
 from zarrita.indexing import morton_order_iter
 from zarrita.metadata import CodecMetadata
 

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -9,7 +9,7 @@ import wkw
 import zarr
 from pytest import fixture
 
-from zarrita import Array, Group, LocalStore, Store, codecs, runtime_configuration
+from zarrita import Array, Group, LocalStore, MemoryStore, Store, codecs, runtime_configuration
 from zarrita.indexing import morton_order_iter
 from zarrita.metadata import CodecMetadata
 
@@ -21,15 +21,18 @@ def l4_sample_data() -> np.ndarray:
     )[0]
 
 
-@fixture
-def store() -> Iterator[Store]:
-    path = Path("testdata")
-    rmtree(path, ignore_errors=True)
-    try:
-        yield LocalStore(path)
-    finally:
-        # rmtree(path, ignore_errors=True)
-        pass
+@fixture(params=["local", "memory"])
+def store(request) -> Iterator[Store]:
+    if request.param == "local":
+        path = Path("testdata")
+        rmtree(path, ignore_errors=True)
+        try:
+            yield LocalStore(path)
+        finally:
+            # rmtree(path, ignore_errors=True)
+            pass
+    elif request.param == "memory":
+        yield MemoryStore()
 
 
 def test_sharding(store: Store, l4_sample_data: np.ndarray):
@@ -237,12 +240,9 @@ async def test_order(
             order=store_order,
             compressor=None,
             fill_value=1,
-            store="testdata/order_zarr",
         )
         z[:, :] = data
-        assert await store.get_async("order/0.0") == await store.get_async(
-            "order_zarr/0.0"
-        )
+        assert await store.get_async("order/0.0") == z._store["0.0"]
 
 
 @pytest.mark.parametrize("input_order", ["F", "C"])
@@ -352,7 +352,6 @@ async def test_transpose(
             order="F",
             compressor=None,
             fill_value=1,
-            store="testdata/transpose_zarr",
         )
         z[:, :] = data
         assert await store.get_async("transpose/0.0") == await store.get_async(
@@ -633,7 +632,6 @@ async def test_zarr_compat(store: Store):
         dtype=data.dtype,
         compressor=None,
         fill_value=1,
-        store="testdata/zarr_compat2",
     )
 
     await a.async_[:16, :18].set(data)
@@ -641,18 +639,10 @@ async def test_zarr_compat(store: Store):
     assert np.array_equal(data, await a.async_[:16, :18].get())
     assert np.array_equal(data, z2[:16, :18])
 
-    assert await store.get_async("zarr_compat2/0.0") == await store.get_async(
-        "zarr_compat3/0.0"
-    )
-    assert await store.get_async("zarr_compat2/0.1") == await store.get_async(
-        "zarr_compat3/0.1"
-    )
-    assert await store.get_async("zarr_compat2/1.0") == await store.get_async(
-        "zarr_compat3/1.0"
-    )
-    assert await store.get_async("zarr_compat2/1.1") == await store.get_async(
-        "zarr_compat3/1.1"
-    )
+    assert z2._store["0.0"] == await store.get_async("zarr_compat3/0.0")
+    assert z2._store["0.1"] == await store.get_async("zarr_compat3/0.1")
+    assert z2._store["1.0"] == await store.get_async("zarr_compat3/1.0")
+    assert z2._store["1.1"] == await store.get_async("zarr_compat3/1.1")
 
 
 @pytest.mark.asyncio
@@ -676,7 +666,6 @@ async def test_zarr_compat_F(store: Store):
         compressor=None,
         order="F",
         fill_value=1,
-        store="testdata/zarr_compatF2",
     )
 
     await a.async_[:16, :18].set(data)
@@ -684,18 +673,10 @@ async def test_zarr_compat_F(store: Store):
     assert np.array_equal(data, await a.async_[:16, :18].get())
     assert np.array_equal(data, z2[:16, :18])
 
-    assert await store.get_async("zarr_compatF2/0.0") == await store.get_async(
-        "zarr_compatF3/0.0"
-    )
-    assert await store.get_async("zarr_compatF2/0.1") == await store.get_async(
-        "zarr_compatF3/0.1"
-    )
-    assert await store.get_async("zarr_compatF2/1.0") == await store.get_async(
-        "zarr_compatF3/1.0"
-    )
-    assert await store.get_async("zarr_compatF2/1.1") == await store.get_async(
-        "zarr_compatF3/1.1"
-    )
+    assert z2._store["0.0"] == await store.get_async("zarr_compatF3/0.0")
+    assert z2._store["0.1"] == await store.get_async("zarr_compatF3/0.1")
+    assert z2._store["1.0"] == await store.get_async("zarr_compatF3/1.0")
+    assert z2._store["1.1"] == await store.get_async("zarr_compatF3/1.1")
 
 
 @pytest.mark.asyncio
@@ -793,12 +774,9 @@ async def test_endian(store: Store, endian: Literal["big", "little"]):
         dtype=">u2" if endian == "big" else "<u2",
         compressor=None,
         fill_value=1,
-        store="testdata/endian_zarr",
     )
     z[:, :] = data
-    assert await store.get_async("endian/0.0") == await store.get_async(
-        "endian_zarr/0.0"
-    )
+    assert await store.get_async("endian/0.0") == z._store["0.0"]
 
 
 @pytest.mark.parametrize("dtype_input_endian", [">u2", "<u2"])
@@ -832,12 +810,9 @@ async def test_endian_write(
         dtype=">u2" if dtype_store_endian == "big" else "<u2",
         compressor=None,
         fill_value=1,
-        store="testdata/endian_zarr",
     )
     z[:, :] = data
-    assert await store.get_async("endian/0.0") == await store.get_async(
-        "endian_zarr/0.0"
-    )
+    assert await store.get_async("endian/0.0") == z._store["0.0"]
 
 
 def test_invalid_metadata(store: Store):

--- a/zarrita/__init__.py
+++ b/zarrita/__init__.py
@@ -10,6 +10,7 @@ from zarrita.group_v2 import GroupV2  # noqa: F401
 from zarrita.metadata import RuntimeConfiguration, runtime_configuration  # noqa: F401
 from zarrita.store import (  # noqa: F401
     LocalStore,
+    MemoryStore,
     RemoteStore,
     Store,
     StoreLike,

--- a/zarrita/sharding.py
+++ b/zarrita/sharding.py
@@ -490,6 +490,7 @@ class ShardingCodec(ArrayBytesCodec):
         )
 
         if shard_builder.index.is_all_empty():
+            # why is this delete necessary?
             await store_path.delete_async()
         else:
             await store_path.set_async(


### PR DESCRIPTION
We have been experimenting with wrapping zarrita from zarr-python as a potential path for implementing the V3 spec.

We immediately noticed the lack of a memory story, which is really useful for testing purposes. This PR adds the ability to create an in-memory Zarr store with Zarrita. In fact, this approach could be used to wrap any existing key-value store.

Along the way, I did a bit of light refactoring of the tests, since my changes here broke some of the assumptions about where data live. The Zarr compatibility comparisons now all use in-memory storage, which should be faster and simpler.